### PR TITLE
Increase graph limit

### DIFF
--- a/src/applications/maniphest/controller/ManiphestTaskDetailController.php
+++ b/src/applications/maniphest/controller/ManiphestTaskDetailController.php
@@ -80,7 +80,7 @@ final class ManiphestTaskDetailController extends ManiphestController {
     $related_tabs = array();
     $graph_menu = null;
 
-    $graph_limit = 100;
+    $graph_limit = 250;
     $task_graph = id(new ManiphestTaskGraph())
       ->setViewer($viewer)
       ->setSeedPHID($task->getPHID())


### PR DESCRIPTION
Feel free to reject, just wanted to see if we could increase this since it only affects a few tasks and the goal of increasing it would be so we can split them up since its not possible to search for tasks that are children of a specific task.