### PR TITLE
use perl-regexp instead of extended-regexp in diffusion searches

### DIFF
--- a/src/applications/diffusion/conduit/DiffusionSearchQueryConduitAPIMethod.php
+++ b/src/applications/diffusion/conduit/DiffusionSearchQueryConduitAPIMethod.php
@@ -63,7 +63,7 @@ final class DiffusionSearchQueryConduitAPIMethod
     $results = array();
     $future = $repository->getLocalCommandFuture(
       // NOTE: --perl-regexp is available only with libpcre compiled in.
-      'grep --extended-regexp --null -n --no-color -f - %s -- %s',
+      'grep --perl-regexp --null -n --no-color -f - %s -- %s',
       $drequest->getStableCommit(),
       $path);
 


### PR DESCRIPTION
We always link git against libpcre and this sacrifices a small amount of performance for greatly increased functionality.