### PR TITLE
restore old behavior of upgrading Cc to To when there is no To

### DIFF
--- a/src/applications/metamta/storage/PhabricatorMetaMTAMail.php
+++ b/src/applications/metamta/storage/PhabricatorMetaMTAMail.php
@@ -1023,7 +1023,12 @@ final class PhabricatorMetaMTAMail
     // behaving in the same way.
     if (!$add_to) {
       $void_recipient = $this->newVoidEmailAddress();
-      $add_to = array($void_recipient->getAddress());
+      if ($add_cc) {
+        $add_to = $add_cc;
+        $add_cc = array();
+      } else {
+        $add_to = array($void_recipient->getAddress());
+      }
     }
 
     $add_to = array_unique($add_to);


### PR DESCRIPTION
2019-Week 1 changed the behavior of emails with CCs but no Tos.

Previously, the Cc field would be "upgraded" to the To field. Now, the Cc field is left as is and a fake address is set as the To field.

I think this behavior is broken.