### PR TITLE
do not include ssh keys from disabled users

### DIFF
--- a/scripts/ssh/ssh-auth.php
+++ b/scripts/ssh/ssh-auth.php
@@ -56,6 +56,9 @@ if ($authstruct === null) {
     $key_argv = array();
     $object = $ssh_key->getObject();
     if ($object instanceof PhabricatorUser) {
+      if (!$object->isUserActivated()) {
+        continue;
+      }
       $key_argv[] = '--phabricator-ssh-user';
       $key_argv[] = $object->getUsername();
     } else if ($object instanceof AlmanacDevice) {


### PR DESCRIPTION
These get blocked by `ssh-exec` but I see no reason to allow them to authenticate to SSH at all.

Upstream explicitly rejected this change in December 2018, but we don't need to follow their lead.