### PR TITLE
use pygments to highlight python instead of using the bespoke phabricator highlighter

### DIFF
--- a/src/infrastructure/markup/syntax/engine/PhutilDefaultSyntaxHighlighterEngine.php
+++ b/src/infrastructure/markup/syntax/engine/PhutilDefaultSyntaxHighlighterEngine.php
@@ -73,13 +73,6 @@ final class PhutilDefaultSyntaxHighlighterEngine
         ->getHighlightFuture($source);
     }
 
-    if ($language == 'py' || $language == 'python') {
-      return id(new PhutilLexerSyntaxHighlighter())
-        ->setConfig('lexer', new PhutilPythonFragmentLexer())
-        ->setConfig('language', 'py')
-        ->getHighlightFuture($source);
-    }
-
     if ($language == 'java') {
       return id(new PhutilLexerSyntaxHighlighter())
         ->setConfig('lexer', new PhutilJavaFragmentLexer())


### PR DESCRIPTION
Removing this block makes it fall through to the default, which uses Pygments.

This fixes the issue where phabricator diffs only highlight python2 syntax.