### PR TITLE
guard against a malformed block length in PhutilRemarkupEngine

### DIFF
--- a/src/infrastructure/markup/remarkup/PhutilRemarkupEngine.php
+++ b/src/infrastructure/markup/remarkup/PhutilRemarkupEngine.php
@@ -220,7 +220,7 @@ final class PhutilRemarkupEngine extends PhutilMarkupEngine {
 
     foreach ($blocks as $key => $block) {
       $min = $block['start'];
-      $max = $min + $block['num_lines'];
+      $max = min($min + $block['num_lines'], sizeof($text));
 
       $lines = '';
       for ($ii = $min; $ii < $max; $ii++) {


### PR DESCRIPTION
Somehow, a record ended up with a remarkup block whose `num_lines` is bigger than the block itself. Maybe some kind of race condition with editing a comment? Anyhow, this prevents phab from exploding.