### PR TITLE
support GFM-style code blocks

### DIFF
--- a/src/infrastructure/markup/blockrule/PhutilRemarkupCodeBlockRule.php
+++ b/src/infrastructure/markup/blockrule/PhutilRemarkupCodeBlockRule.php
@@ -44,7 +44,14 @@ final class PhutilRemarkupCodeBlockRule extends PhutilRemarkupBlockRule {
   }
 
   public function markupText($text, $children) {
+    $default_lang = null;
+
     if (preg_match('/^\s*```/', $text)) {
+      // Look for GFM-style ```langname blocks and handle them
+      if (preg_match('/\A\s*``` *([a-z]+)\n/', $text, $matches)) {
+        $default_lang = $matches[1];
+        $text = preg_replace('/\A\s*``` *([a-z]+)\n/', '', $text);
+      }
       // If this is a ```-style block, trim off the backticks and any leading
       // blank line.
       $text = preg_replace('/^\s*```(\s*\n)?/', '', $text);
@@ -58,7 +65,7 @@ final class PhutilRemarkupCodeBlockRule extends PhutilRemarkupBlockRule {
 
     $options = array(
       'counterexample'  => false,
-      'lang'            => null,
+      'lang'            => $default_lang,
       'name'            => null,
       'lines'           => null,
     );

--- a/src/infrastructure/markup/blockrule/PhutilRemarkupCodeBlockRule.php
+++ b/src/infrastructure/markup/blockrule/PhutilRemarkupCodeBlockRule.php
@@ -48,9 +48,9 @@ final class PhutilRemarkupCodeBlockRule extends PhutilRemarkupBlockRule {
 
     if (preg_match('/^\s*```/', $text)) {
       // Look for GFM-style ```langname blocks and handle them
-      if (preg_match('/\A\s*``` *([a-z]+)\n/', $text, $matches)) {
+      if (preg_match('/^\s*``` *([a-z]+)\n/', $text, $matches)) {
         $default_lang = $matches[1];
-        $text = preg_replace('/\A\s*``` *([a-z]+)\n/', '', $text);
+        $text = preg_replace('/^\s*``` *([a-z]+)\n/', '', $text);
       }
       // If this is a ```-style block, trim off the backticks and any leading
       // blank line.


### PR DESCRIPTION
This allows you to use GitHub-flavored markdown's way of specifying the programming language for highlighting a code block, and thus improves compatibility when rendering READMEs from non-Phabricator projects. I doubt there are any real cases where someone did ```python and expected anything else?